### PR TITLE
Make gnome-shell friendly by using transient notifications

### DIFF
--- a/bin/an-install
+++ b/bin/an-install
@@ -60,8 +60,8 @@ BANNER
           "but there are pending specs. Only for Mac.") { |pending| OPTIONS[:pending] = true }
     
   opts.on("--sticky",
-          "Keep notification on screen in case of errros/failures or pending specs.",
-          "Only for Mac.") { |sticky| OPTIONS[:sticky] = true }
+          "Keep notification on screen in case of errros/failures.",
+          "Only for Mac and Linux.") { |sticky| OPTIONS[:sticky] = true }
           
   opts.on("--success-sound=PATH", String,
           "Sound to play on success.", 

--- a/lib/autotest_notification/linux.rb
+++ b/lib/autotest_notification/linux.rb
@@ -31,8 +31,8 @@ module AutotestNotification
         end
         
         def notify_send(title, msg, img, priority = 0)
-          urgency = priority > 1 ? 'critical' : priority < 0 ? 'low' : 'normal'
-          system "notify-send -t #{Config.expiration_in_seconds * 1000} -i #{img} -u #{urgency} '#{title}' '#{msg}'"
+          urgency = priority < 0 ? 'low' : Config.expiration_in_seconds > 0 ? 'normal' : 'critical'
+          system "notify-send -h int:transient:1 -t #{Config.expiration_in_seconds * 1000} -i #{img} -u #{urgency} '#{title}' '#{msg}'"
         end
 
         def kdialog(title, msg, img)


### PR DESCRIPTION
Makes autotest-notification consistent with intent by preventing the message tray from filling up with persistent notifications. I'm unable to test this change on other libnotify environments to ensure that the original behaviour remains, I believe it should but  that will need to be checked by people with other desktops.

The behaviour is as follows:

If STICKY && (failures||errors) notification remains on screen, otherwise notification expires.
In both cases notifications are transient, so will not remain in the message tray.
