### PR TITLE
Fix for Windows (mingw)

### DIFF
--- a/autotest-notification.gemspec
+++ b/autotest-notification.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{autotest-notification}
-  s.version = "2.3.3"
+  s.version = "2.3.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Carlos Brando"]

--- a/lib/autotest_notification.rb
+++ b/lib/autotest_notification.rb
@@ -102,6 +102,8 @@ module AutotestNotification
         Cygwin.notify(title, msg, img, total, failures)
       when /mswin/
         Windows.notify(title, msg, img)
+      when /mingw/
+        Windows.notify(title, msg, img)
       end
     end
 

--- a/lib/autotest_notification.rb
+++ b/lib/autotest_notification.rb
@@ -3,7 +3,7 @@ $:.unshift(File.dirname(__FILE__))
 
 module AutotestNotification
   
-  VERSION = '2.3.2'
+  VERSION = '2.3.4'
   
   class Config
 

--- a/lib/autotest_notification/windows.rb
+++ b/lib/autotest_notification/windows.rb
@@ -1,4 +1,4 @@
-require 'snarl' if RUBY_PLATFORM =~ /mswin/
+require 'snarl' if RUBY_PLATFORM =~ /mswin/ or RUBY_PLATFORM =~ /mingw/
 
 module AutotestNotification
   class Windows


### PR DESCRIPTION
http://www.railsinstaller.org is a popular Windows solution for installing the Ruby and Rails environment.  However, RUBY_PLATFORM is "i386-mingw32", not "mswin":

C:\code\ref\autotest-notification>irb
irb(main):001:0> require 'rubygems'
=> true
irb(main):002:0> RUBY_PLATFORM
=> "i386-mingw32"

Currently, autotest-notification only checks for "mswin", not "mingw".  This patch adds checks for mingw, enabling this gem to work correctly on Windows.
